### PR TITLE
[ISSUE-9] feat: add put/get/rm/acl CLI subcommands; drop cobra completion

### DIFF
--- a/cmd/imghost/cmd/acl.go
+++ b/cmd/imghost/cmd/acl.go
@@ -24,21 +24,26 @@ var aclGetCmd = &cobra.Command{
 	Args:              cobra.ExactArgs(1),
 	PersistentPreRunE: requireConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := configLoader()
+		remote := normalizeRemote(args[0])
+		u := aclURL(mustConfig(), remote)
+		resp, err := httpDo("GET", u, mustConfig().APIKey, nil, "")
 		if err != nil {
-			return err
-		}
-		u := aclURL(cfg, args[0])
-		resp, err := httpDo("GET", u, cfg.APIKey, nil, "")
-		if err != nil {
-			return err
+			return formatCLIError("acl get", remote, err)
 		}
 		defer resp.Body.Close()
-		_, err = io.Copy(cmd.OutOrStdout(), resp.Body)
-		if err == nil {
-			fmt.Fprintln(cmd.OutOrStdout())
+		raw, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return formatCLIError("acl get", remote, err)
 		}
-		return err
+		var body struct {
+			Path   string `json:"path"`
+			Access string `json:"access"`
+		}
+		if err := json.Unmarshal(raw, &body); err != nil || body.Access == "" {
+			return formatCLIError("acl get", remote, fmt.Errorf("unexpected response: %s", string(raw)))
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s: %s\n", remote, body.Access)
+		return nil
 	},
 }
 
@@ -48,22 +53,20 @@ var aclSetCmd = &cobra.Command{
 	Args:              cobra.ExactArgs(2),
 	PersistentPreRunE: requireConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := configLoader()
-		if err != nil {
-			return err
-		}
+		remote := normalizeRemote(args[0])
 		access, err := permission.Parse(args[1])
 		if err != nil {
-			return fmt.Errorf("invalid access %q: must be public or private", args[1])
+			return formatCLIError("acl set", remote, fmt.Errorf("invalid access %q: must be public or private", args[1]))
 		}
 		body, _ := json.Marshal(map[string]string{"access": string(access)})
-		u := aclURL(cfg, args[0])
-		resp, err := httpDo("PUT", u, cfg.APIKey, bytes.NewReader(body), "application/json")
+		u := aclURL(mustConfig(), remote)
+		resp, err := httpDo("PUT", u, mustConfig().APIKey, bytes.NewReader(body), "application/json")
 		if err != nil {
-			return err
+			return formatCLIError("acl set", remote, err)
 		}
 		defer resp.Body.Close()
-		fmt.Fprintln(cmd.OutOrStdout(), resp.Status)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		fmt.Fprintf(cmd.OutOrStdout(), "acl set %s = %s\n", remote, access)
 		return nil
 	},
 }
@@ -74,17 +77,15 @@ var aclRmCmd = &cobra.Command{
 	Args:              cobra.ExactArgs(1),
 	PersistentPreRunE: requireConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := configLoader()
+		remote := normalizeRemote(args[0])
+		u := aclURL(mustConfig(), remote)
+		resp, err := httpDo("DELETE", u, mustConfig().APIKey, nil, "")
 		if err != nil {
-			return err
-		}
-		u := aclURL(cfg, args[0])
-		resp, err := httpDo("DELETE", u, cfg.APIKey, nil, "")
-		if err != nil {
-			return err
+			return formatCLIError("acl rm", remote, err)
 		}
 		defer resp.Body.Close()
-		fmt.Fprintln(cmd.OutOrStdout(), resp.Status)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		fmt.Fprintf(cmd.OutOrStdout(), "acl cleared %s\n", remote)
 		return nil
 	},
 }

--- a/cmd/imghost/cmd/acl.go
+++ b/cmd/imghost/cmd/acl.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+
+	"github.com/spf13/cobra"
+
+	"github.com/1996fanrui/imghost/internal/config"
+	"github.com/1996fanrui/imghost/internal/permission"
+)
+
+var aclCmd = &cobra.Command{
+	Use:   "acl",
+	Short: "Manage per-path ACL overrides",
+}
+
+var aclGetCmd = &cobra.Command{
+	Use:               "get <remote-path>",
+	Short:             "Read the explicit ACL for <remote-path>",
+	Args:              cobra.ExactArgs(1),
+	PersistentPreRunE: requireConfig,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := configLoader()
+		if err != nil {
+			return err
+		}
+		u := aclURL(cfg, args[0])
+		resp, err := httpDo("GET", u, cfg.APIKey, nil, "")
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		_, err = io.Copy(cmd.OutOrStdout(), resp.Body)
+		if err == nil {
+			fmt.Fprintln(cmd.OutOrStdout())
+		}
+		return err
+	},
+}
+
+var aclSetCmd = &cobra.Command{
+	Use:               "set <remote-path> <public|private>",
+	Short:             "Set the explicit ACL for <remote-path>",
+	Args:              cobra.ExactArgs(2),
+	PersistentPreRunE: requireConfig,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := configLoader()
+		if err != nil {
+			return err
+		}
+		access, err := permission.Parse(args[1])
+		if err != nil {
+			return fmt.Errorf("invalid access %q: must be public or private", args[1])
+		}
+		body, _ := json.Marshal(map[string]string{"access": string(access)})
+		u := aclURL(cfg, args[0])
+		resp, err := httpDo("PUT", u, cfg.APIKey, bytes.NewReader(body), "application/json")
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		fmt.Fprintln(cmd.OutOrStdout(), resp.Status)
+		return nil
+	},
+}
+
+var aclRmCmd = &cobra.Command{
+	Use:               "rm <remote-path>",
+	Short:             "Remove the explicit ACL for <remote-path>",
+	Args:              cobra.ExactArgs(1),
+	PersistentPreRunE: requireConfig,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := configLoader()
+		if err != nil {
+			return err
+		}
+		u := aclURL(cfg, args[0])
+		resp, err := httpDo("DELETE", u, cfg.APIKey, nil, "")
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		fmt.Fprintln(cmd.OutOrStdout(), resp.Status)
+		return nil
+	},
+}
+
+func init() {
+	aclCmd.AddCommand(aclGetCmd, aclSetCmd, aclRmCmd)
+}
+
+// aclURL builds "<base>/<remote-path>?acl" with the path properly escaped.
+func aclURL(cfg *config.Config, remote string) string {
+	u := url.URL{Path: normalizeRemote(remote), RawQuery: "acl"}
+	return baseURL(cfg) + u.EscapedPath() + "?" + u.RawQuery
+}

--- a/cmd/imghost/cmd/http_client.go
+++ b/cmd/imghost/cmd/http_client.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -30,8 +31,9 @@ func normalizeRemote(p string) string {
 }
 
 // httpDo executes an authenticated HTTP request against the daemon. On
-// non-2xx responses it returns an error carrying the server's response body
-// so users see the daemon's structured error (apierror.Response) verbatim.
+// non-2xx responses it returns an error whose message is the server's
+// apierror.Response.message field (parsed from JSON); callers wrap it with
+// operation context via formatCLIError.
 func httpDo(method, url, apiKey string, body io.Reader, contentType string) (*http.Response, error) {
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
@@ -47,8 +49,52 @@ func httpDo(method, url, apiKey string, body io.Reader, contentType string) (*ht
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		defer resp.Body.Close()
-		msg, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(msg)))
+		return nil, parseServerError(resp)
 	}
 	return resp, nil
+}
+
+// parseServerError reads the response body and extracts a concise, human
+// message from the server's structured error (apierror.Response). If the
+// body is not a recognizable JSON error, falls back to the HTTP status.
+func parseServerError(resp *http.Response) error {
+	raw, _ := io.ReadAll(resp.Body)
+	var body struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(raw, &body); err == nil && body.Message != "" {
+		return fmt.Errorf("%s", body.Message)
+	}
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed != "" {
+		return fmt.Errorf("%s: %s", resp.Status, trimmed)
+	}
+	return fmt.Errorf("%s", resp.Status)
+}
+
+// formatCLIError produces the unified CLI error format:
+//
+//	imghost: <op> <target>: <reason>
+//
+// Cobra prints the returned error to stderr; SilenceErrors on the root
+// prevents the default "Error: ..." prefix so this is the only line shown.
+func formatCLIError(op, target string, err error) error {
+	return fmt.Errorf("imghost: %s %s: %w", op, target, err)
+}
+
+// humanBytes renders a byte count as a short, human-readable string.
+// Used in success messages so users see "uploaded /a.txt (1.4 KiB)" rather
+// than raw byte counts.
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for v := n / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
 }

--- a/cmd/imghost/cmd/http_client.go
+++ b/cmd/imghost/cmd/http_client.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/1996fanrui/imghost/internal/config"
+)
+
+// baseURL derives the daemon URL from cfg.ListenAddr. A leading ":port"
+// (the config default) is interpreted as 127.0.0.1:port because the daemon
+// binds all interfaces but a CLI on the same host always reaches it via
+// loopback.
+func baseURL(cfg *config.Config) string {
+	addr := cfg.ListenAddr
+	if strings.HasPrefix(addr, ":") {
+		addr = "127.0.0.1" + addr
+	}
+	return "http://" + addr
+}
+
+// normalizeRemote ensures the remote path starts with exactly one slash.
+func normalizeRemote(p string) string {
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	return p
+}
+
+// httpDo executes an authenticated HTTP request against the daemon. On
+// non-2xx responses it returns an error carrying the server's response body
+// so users see the daemon's structured error (apierror.Response) verbatim.
+func httpDo(method, url, apiKey string, body io.Reader, contentType string) (*http.Response, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		defer resp.Body.Close()
+		msg, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(msg)))
+	}
+	return resp, nil
+}

--- a/cmd/imghost/cmd/http_commands_test.go
+++ b/cmd/imghost/cmd/http_commands_test.go
@@ -1,0 +1,179 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/1996fanrui/imghost/internal/config"
+)
+
+// withHTTPTestEnv points configLoader at a stub server and returns the
+// server so tests can record requests. The apiKey is asserted on the
+// server side.
+func withHTTPTestEnv(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse srv url: %v", err)
+	}
+	origLoader := configLoader
+	configLoader = func() (*config.Config, error) {
+		return &config.Config{ListenAddr: u.Host, APIKey: "test-key"}, nil
+	}
+	t.Cleanup(func() { configLoader = origLoader })
+	return srv
+}
+
+func runCLI(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	return buf.String(), err
+}
+
+type recorded struct {
+	method, path, query, auth, ctype string
+	body                             []byte
+}
+
+func recordingHandler(rec *recorded, status int, respBody string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.method = r.Method
+		rec.path = r.URL.Path
+		rec.query = r.URL.RawQuery
+		rec.auth = r.Header.Get("Authorization")
+		rec.ctype = r.Header.Get("Content-Type")
+		rec.body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, respBody)
+	})
+}
+
+func TestPutSendsFile(t *testing.T) {
+	var rec recorded
+	withHTTPTestEnv(t, recordingHandler(&rec, 200, "ok"))
+	dir := t.TempDir()
+	local := filepath.Join(dir, "a.txt")
+	if err := os.WriteFile(local, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCLI(t, "put", "/photos/a.txt", local); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if rec.method != "PUT" || rec.path != "/photos/a.txt" {
+		t.Errorf("method/path: %s %s", rec.method, rec.path)
+	}
+	if rec.auth != "Bearer test-key" {
+		t.Errorf("auth: %q", rec.auth)
+	}
+	if string(rec.body) != "hello" {
+		t.Errorf("body: %q", rec.body)
+	}
+}
+
+func TestGetWritesOutputFile(t *testing.T) {
+	var rec recorded
+	withHTTPTestEnv(t, recordingHandler(&rec, 200, "payload"))
+	dir := t.TempDir()
+	out := filepath.Join(dir, "x.bin")
+	if _, err := runCLI(t, "get", "photos/cat.jpg", "-o", out); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if rec.method != "GET" || rec.path != "/photos/cat.jpg" {
+		t.Errorf("method/path: %s %s", rec.method, rec.path)
+	}
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "payload" {
+		t.Errorf("output: %q", got)
+	}
+}
+
+func TestRmSendsDelete(t *testing.T) {
+	var rec recorded
+	withHTTPTestEnv(t, recordingHandler(&rec, 204, ""))
+	if _, err := runCLI(t, "rm", "/photos/a.txt"); err != nil {
+		t.Fatalf("rm: %v", err)
+	}
+	if rec.method != "DELETE" || rec.path != "/photos/a.txt" {
+		t.Errorf("method/path: %s %s", rec.method, rec.path)
+	}
+}
+
+func TestACLGet(t *testing.T) {
+	var rec recorded
+	withHTTPTestEnv(t, recordingHandler(&rec, 200, `{"path":"/photos/a","access":"public"}`))
+	out, err := runCLI(t, "acl", "get", "/photos/a")
+	if err != nil {
+		t.Fatalf("acl get: %v", err)
+	}
+	if rec.method != "GET" || rec.path != "/photos/a" || rec.query != "acl" {
+		t.Errorf("req: %s %s?%s", rec.method, rec.path, rec.query)
+	}
+	if !strings.Contains(out, `"access":"public"`) {
+		t.Errorf("output: %q", out)
+	}
+}
+
+func TestACLSet(t *testing.T) {
+	var rec recorded
+	withHTTPTestEnv(t, recordingHandler(&rec, 200, ""))
+	if _, err := runCLI(t, "acl", "set", "/p/a", "private"); err != nil {
+		t.Fatalf("acl set: %v", err)
+	}
+	if rec.method != "PUT" || rec.query != "acl" || rec.ctype != "application/json" {
+		t.Errorf("req headers: %s ?%s ct=%s", rec.method, rec.query, rec.ctype)
+	}
+	if !strings.Contains(string(rec.body), `"access":"private"`) {
+		t.Errorf("body: %q", rec.body)
+	}
+}
+
+func TestACLSetRejectsInvalidAccess(t *testing.T) {
+	withHTTPTestEnv(t, recordingHandler(&recorded{}, 500, "should not be called"))
+	if _, err := runCLI(t, "acl", "set", "/p/a", "bogus"); err == nil {
+		t.Fatal("expected error for invalid access value")
+	}
+}
+
+func TestACLRm(t *testing.T) {
+	var rec recorded
+	withHTTPTestEnv(t, recordingHandler(&rec, 204, ""))
+	if _, err := runCLI(t, "acl", "rm", "/p/a"); err != nil {
+		t.Fatalf("acl rm: %v", err)
+	}
+	if rec.method != "DELETE" || rec.query != "acl" {
+		t.Errorf("req: %s ?%s", rec.method, rec.query)
+	}
+}
+
+func TestNon2xxReturnsError(t *testing.T) {
+	withHTTPTestEnv(t, recordingHandler(&recorded{}, 403, `{"error":"forbidden path"}`))
+	if _, err := runCLI(t, "rm", "/p/a"); err == nil {
+		t.Fatal("expected non-nil error for 403")
+	}
+}
+
+func TestCompletionSubcommandDisabled(t *testing.T) {
+	// Defensive: ensure `imghost completion` is not a registered subcommand.
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "completion" {
+			t.Fatalf("completion subcommand should be disabled, found %q", c.Name())
+		}
+	}
+}

--- a/cmd/imghost/cmd/http_commands_test.go
+++ b/cmd/imghost/cmd/http_commands_test.go
@@ -27,10 +27,14 @@ func withHTTPTestEnv(t *testing.T, handler http.Handler) *httptest.Server {
 		t.Fatalf("parse srv url: %v", err)
 	}
 	origLoader := configLoader
+	origCached := cachedConfig
 	configLoader = func() (*config.Config, error) {
 		return &config.Config{ListenAddr: u.Host, APIKey: "test-key"}, nil
 	}
-	t.Cleanup(func() { configLoader = origLoader })
+	t.Cleanup(func() {
+		configLoader = origLoader
+		cachedConfig = origCached
+	})
 	return srv
 }
 
@@ -62,7 +66,7 @@ func recordingHandler(rec *recorded, status int, respBody string) http.Handler {
 	})
 }
 
-func TestPutSendsFile(t *testing.T) {
+func TestPutPrintsSuccessLine(t *testing.T) {
 	var rec recorded
 	withHTTPTestEnv(t, recordingHandler(&rec, 200, "ok"))
 	dir := t.TempDir()
@@ -70,7 +74,8 @@ func TestPutSendsFile(t *testing.T) {
 	if err := os.WriteFile(local, []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := runCLI(t, "put", "/photos/a.txt", local); err != nil {
+	out, err := runCLI(t, "put", "/photos/a.txt", local)
+	if err != nil {
 		t.Fatalf("put: %v", err)
 	}
 	if rec.method != "PUT" || rec.path != "/photos/a.txt" {
@@ -82,40 +87,84 @@ func TestPutSendsFile(t *testing.T) {
 	if string(rec.body) != "hello" {
 		t.Errorf("body: %q", rec.body)
 	}
+	if !strings.Contains(out, "uploaded /photos/a.txt") {
+		t.Errorf("success line missing: %q", out)
+	}
 }
 
-func TestGetWritesOutputFile(t *testing.T) {
+func TestGetDefaultSavesBasename(t *testing.T) {
 	var rec recorded
 	withHTTPTestEnv(t, recordingHandler(&rec, 200, "payload"))
 	dir := t.TempDir()
-	out := filepath.Join(dir, "x.bin")
-	if _, err := runCLI(t, "get", "photos/cat.jpg", "-o", out); err != nil {
+	t.Chdir(dir)
+	out, err := runCLI(t, "get", "/photos/cat.jpg")
+	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
-	if rec.method != "GET" || rec.path != "/photos/cat.jpg" {
-		t.Errorf("method/path: %s %s", rec.method, rec.path)
+	got, err := os.ReadFile(filepath.Join(dir, "cat.jpg"))
+	if err != nil {
+		t.Fatalf("expected ./cat.jpg to exist: %v", err)
 	}
-	got, err := os.ReadFile(out)
+	if string(got) != "payload" {
+		t.Errorf("payload: %q", got)
+	}
+	if !strings.Contains(out, "saved /photos/cat.jpg -> ./cat.jpg") {
+		t.Errorf("success line missing: %q", out)
+	}
+}
+
+func TestGetOutputFlag(t *testing.T) {
+	var rec recorded
+	withHTTPTestEnv(t, recordingHandler(&rec, 200, "payload"))
+	dir := t.TempDir()
+	target := filepath.Join(dir, "x.bin")
+	out, err := runCLI(t, "get", "/photos/cat.jpg", "-o", target)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	got, err := os.ReadFile(target)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(got) != "payload" {
-		t.Errorf("output: %q", got)
+		t.Errorf("payload: %q", got)
+	}
+	if !strings.Contains(out, target) {
+		t.Errorf("success line should reference custom path: %q", out)
 	}
 }
 
-func TestRmSendsDelete(t *testing.T) {
+func TestGetStdoutMode(t *testing.T) {
+	var rec recorded
+	withHTTPTestEnv(t, recordingHandler(&rec, 200, "payload"))
+	out, err := runCLI(t, "get", "/photos/cat.jpg", "-o", "-")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !strings.Contains(out, "payload") {
+		t.Errorf("stdout should contain raw bytes: %q", out)
+	}
+	if strings.Contains(out, "saved") {
+		t.Errorf("stdout mode must stay silent on success line: %q", out)
+	}
+}
+
+func TestRmPrintsRemovedLine(t *testing.T) {
 	var rec recorded
 	withHTTPTestEnv(t, recordingHandler(&rec, 204, ""))
-	if _, err := runCLI(t, "rm", "/photos/a.txt"); err != nil {
+	out, err := runCLI(t, "rm", "/photos/a.txt")
+	if err != nil {
 		t.Fatalf("rm: %v", err)
 	}
 	if rec.method != "DELETE" || rec.path != "/photos/a.txt" {
 		t.Errorf("method/path: %s %s", rec.method, rec.path)
 	}
+	if !strings.Contains(out, "removed /photos/a.txt") {
+		t.Errorf("success line missing: %q", out)
+	}
 }
 
-func TestACLGet(t *testing.T) {
+func TestACLGetPrintsOneLiner(t *testing.T) {
 	var rec recorded
 	withHTTPTestEnv(t, recordingHandler(&rec, 200, `{"path":"/photos/a","access":"public"}`))
 	out, err := runCLI(t, "acl", "get", "/photos/a")
@@ -125,7 +174,7 @@ func TestACLGet(t *testing.T) {
 	if rec.method != "GET" || rec.path != "/photos/a" || rec.query != "acl" {
 		t.Errorf("req: %s %s?%s", rec.method, rec.path, rec.query)
 	}
-	if !strings.Contains(out, `"access":"public"`) {
+	if !strings.Contains(out, "/photos/a: public") {
 		t.Errorf("output: %q", out)
 	}
 }
@@ -133,7 +182,8 @@ func TestACLGet(t *testing.T) {
 func TestACLSet(t *testing.T) {
 	var rec recorded
 	withHTTPTestEnv(t, recordingHandler(&rec, 200, ""))
-	if _, err := runCLI(t, "acl", "set", "/p/a", "private"); err != nil {
+	out, err := runCLI(t, "acl", "set", "/p/a", "private")
+	if err != nil {
 		t.Fatalf("acl set: %v", err)
 	}
 	if rec.method != "PUT" || rec.query != "acl" || rec.ctype != "application/json" {
@@ -142,35 +192,55 @@ func TestACLSet(t *testing.T) {
 	if !strings.Contains(string(rec.body), `"access":"private"`) {
 		t.Errorf("body: %q", rec.body)
 	}
+	if !strings.Contains(out, "acl set /p/a = private") {
+		t.Errorf("output: %q", out)
+	}
 }
 
 func TestACLSetRejectsInvalidAccess(t *testing.T) {
 	withHTTPTestEnv(t, recordingHandler(&recorded{}, 500, "should not be called"))
-	if _, err := runCLI(t, "acl", "set", "/p/a", "bogus"); err == nil {
+	_, err := runCLI(t, "acl", "set", "/p/a", "bogus")
+	if err == nil {
 		t.Fatal("expected error for invalid access value")
+	}
+	if !strings.Contains(err.Error(), "imghost: acl set /p/a") {
+		t.Errorf("error must use unified format: %v", err)
 	}
 }
 
 func TestACLRm(t *testing.T) {
 	var rec recorded
 	withHTTPTestEnv(t, recordingHandler(&rec, 204, ""))
-	if _, err := runCLI(t, "acl", "rm", "/p/a"); err != nil {
+	out, err := runCLI(t, "acl", "rm", "/p/a")
+	if err != nil {
 		t.Fatalf("acl rm: %v", err)
 	}
 	if rec.method != "DELETE" || rec.query != "acl" {
 		t.Errorf("req: %s ?%s", rec.method, rec.query)
 	}
+	if !strings.Contains(out, "acl cleared /p/a") {
+		t.Errorf("output: %q", out)
+	}
 }
 
-func TestNon2xxReturnsError(t *testing.T) {
-	withHTTPTestEnv(t, recordingHandler(&recorded{}, 403, `{"error":"forbidden path"}`))
-	if _, err := runCLI(t, "rm", "/p/a"); err == nil {
-		t.Fatal("expected non-nil error for 403")
+func TestErrorIncludesServerMessage(t *testing.T) {
+	// 404 with apierror.Response JSON body must surface the message field,
+	// wrapped in the unified "imghost: <op> <target>: <reason>" form.
+	withHTTPTestEnv(t, recordingHandler(&recorded{}, 404, `{"error":"not_found","message":"not found"}`))
+	_, err := runCLI(t, "rm", "/p/a")
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "imghost: rm /p/a:") || !strings.Contains(got, "not found") {
+		t.Errorf("unexpected error format: %q", got)
+	}
+	if strings.Contains(got, "404") || strings.Contains(got, "{") {
+		t.Errorf("raw HTTP status / JSON leaked into user-facing error: %q", got)
 	}
 }
 
 func TestCompletionSubcommandDisabled(t *testing.T) {
-	// Defensive: ensure `imghost completion` is not a registered subcommand.
 	for _, c := range rootCmd.Commands() {
 		if c.Name() == "completion" {
 			t.Fatalf("completion subcommand should be disabled, found %q", c.Name())

--- a/cmd/imghost/cmd/object.go
+++ b/cmd/imghost/cmd/object.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"path"
 
 	"github.com/spf13/cobra"
 )
@@ -15,24 +16,28 @@ var putCmd = &cobra.Command{
 	Args:              cobra.ExactArgs(2),
 	PersistentPreRunE: requireConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := configLoader()
-		if err != nil {
-			return err
-		}
 		remote := normalizeRemote(args[0])
 		local := args[1]
+		info, err := os.Stat(local)
+		if err != nil {
+			return formatCLIError("put", remote, err)
+		}
+		if info.IsDir() {
+			return formatCLIError("put", remote, fmt.Errorf("%s is a directory", local))
+		}
 		f, err := os.Open(local)
 		if err != nil {
-			return err
+			return formatCLIError("put", remote, err)
 		}
 		defer f.Close()
-		u := baseURL(cfg) + (&url.URL{Path: remote}).EscapedPath()
-		resp, err := httpDo("PUT", u, cfg.APIKey, f, "application/octet-stream")
+		u := baseURL(mustConfig()) + (&url.URL{Path: remote}).EscapedPath()
+		resp, err := httpDo("PUT", u, mustConfig().APIKey, f, "application/octet-stream")
 		if err != nil {
-			return err
+			return formatCLIError("put", remote, err)
 		}
 		defer resp.Body.Close()
-		_, _ = io.Copy(cmd.OutOrStdout(), resp.Body)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		fmt.Fprintf(cmd.OutOrStdout(), "uploaded %s (%s)\n", remote, humanBytes(info.Size()))
 		return nil
 	},
 }
@@ -46,34 +51,52 @@ var (
 		Args:              cobra.ExactArgs(1),
 		PersistentPreRunE: requireConfig,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := configLoader()
-			if err != nil {
-				return err
-			}
 			remote := normalizeRemote(args[0])
-			u := baseURL(cfg) + (&url.URL{Path: remote}).EscapedPath()
-			resp, err := httpDo("GET", u, cfg.APIKey, nil, "")
+			u := baseURL(mustConfig()) + (&url.URL{Path: remote}).EscapedPath()
+			resp, err := httpDo("GET", u, mustConfig().APIKey, nil, "")
 			if err != nil {
-				return err
+				return formatCLIError("get", remote, err)
 			}
 			defer resp.Body.Close()
-			var dst io.Writer = cmd.OutOrStdout()
-			if getOutput != "" && getOutput != "-" {
-				f, err := os.Create(getOutput)
-				if err != nil {
-					return err
-				}
-				defer f.Close()
-				dst = f
+
+			// Output routing:
+			//   -o <path>  → that file
+			//   -o -       → stdout
+			//   (unset)    → ./<basename of remote>
+			target := getOutput
+			if target == "" {
+				target = "./" + path.Base(remote)
 			}
-			_, err = io.Copy(dst, resp.Body)
-			return err
+
+			if target == "-" {
+				n, err := io.Copy(cmd.OutOrStdout(), resp.Body)
+				if err != nil {
+					return formatCLIError("get", remote, err)
+				}
+				// Stdout mode stays silent on stderr so the user can pipe
+				// the bytes. The byte count is useful but not user-facing
+				// here; keep stdout pristine.
+				_ = n
+				return nil
+			}
+
+			f, err := os.Create(target)
+			if err != nil {
+				return formatCLIError("get", remote, err)
+			}
+			defer f.Close()
+			n, err := io.Copy(f, resp.Body)
+			if err != nil {
+				return formatCLIError("get", remote, err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "saved %s -> %s (%s)\n", remote, target, humanBytes(n))
+			return nil
 		},
 	}
 )
 
 func init() {
-	getCmd.Flags().StringVarP(&getOutput, "output", "o", "", "write response body to file (default: stdout)")
+	getCmd.Flags().StringVarP(&getOutput, "output", "o", "", "write to file (default ./<basename>); use - for stdout")
 }
 
 var rmCmd = &cobra.Command{
@@ -82,18 +105,15 @@ var rmCmd = &cobra.Command{
 	Args:              cobra.ExactArgs(1),
 	PersistentPreRunE: requireConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := configLoader()
-		if err != nil {
-			return err
-		}
 		remote := normalizeRemote(args[0])
-		u := baseURL(cfg) + (&url.URL{Path: remote}).EscapedPath()
-		resp, err := httpDo("DELETE", u, cfg.APIKey, nil, "")
+		u := baseURL(mustConfig()) + (&url.URL{Path: remote}).EscapedPath()
+		resp, err := httpDo("DELETE", u, mustConfig().APIKey, nil, "")
 		if err != nil {
-			return err
+			return formatCLIError("rm", remote, err)
 		}
 		defer resp.Body.Close()
-		fmt.Fprintln(cmd.OutOrStdout(), resp.Status)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		fmt.Fprintf(cmd.OutOrStdout(), "removed %s\n", remote)
 		return nil
 	},
 }

--- a/cmd/imghost/cmd/object.go
+++ b/cmd/imghost/cmd/object.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var putCmd = &cobra.Command{
+	Use:               "put <remote-path> <local-file>",
+	Short:             "Upload a local file to the daemon at <remote-path>",
+	Args:              cobra.ExactArgs(2),
+	PersistentPreRunE: requireConfig,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := configLoader()
+		if err != nil {
+			return err
+		}
+		remote := normalizeRemote(args[0])
+		local := args[1]
+		f, err := os.Open(local)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		u := baseURL(cfg) + (&url.URL{Path: remote}).EscapedPath()
+		resp, err := httpDo("PUT", u, cfg.APIKey, f, "application/octet-stream")
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		_, _ = io.Copy(cmd.OutOrStdout(), resp.Body)
+		return nil
+	},
+}
+
+var (
+	getOutput string
+
+	getCmd = &cobra.Command{
+		Use:               "get <remote-path>",
+		Short:             "Download <remote-path> from the daemon",
+		Args:              cobra.ExactArgs(1),
+		PersistentPreRunE: requireConfig,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := configLoader()
+			if err != nil {
+				return err
+			}
+			remote := normalizeRemote(args[0])
+			u := baseURL(cfg) + (&url.URL{Path: remote}).EscapedPath()
+			resp, err := httpDo("GET", u, cfg.APIKey, nil, "")
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			var dst io.Writer = cmd.OutOrStdout()
+			if getOutput != "" && getOutput != "-" {
+				f, err := os.Create(getOutput)
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+				dst = f
+			}
+			_, err = io.Copy(dst, resp.Body)
+			return err
+		},
+	}
+)
+
+func init() {
+	getCmd.Flags().StringVarP(&getOutput, "output", "o", "", "write response body to file (default: stdout)")
+}
+
+var rmCmd = &cobra.Command{
+	Use:               "rm <remote-path>",
+	Short:             "Delete <remote-path> on the daemon",
+	Args:              cobra.ExactArgs(1),
+	PersistentPreRunE: requireConfig,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := configLoader()
+		if err != nil {
+			return err
+		}
+		remote := normalizeRemote(args[0])
+		u := baseURL(cfg) + (&url.URL{Path: remote}).EscapedPath()
+		resp, err := httpDo("DELETE", u, cfg.APIKey, nil, "")
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		fmt.Fprintln(cmd.OutOrStdout(), resp.Status)
+		return nil
+	},
+}

--- a/cmd/imghost/cmd/root.go
+++ b/cmd/imghost/cmd/root.go
@@ -20,11 +20,11 @@ const UnitName = "imghostd"
 var NotInstalledMessage string
 
 // configLoader is the hook through which non-version subcommands verify
-// that the shared XDG config is readable. Tests swap this out so the CLI
+// that the shared XDG config is readable and retrieve settings (listen_addr,
+// api_key) needed to talk to the daemon. Tests swap this out so the CLI
 // never touches the real filesystem.
-var configLoader = func() error {
-	_, err := config.Load()
-	return err
+var configLoader = func() (*config.Config, error) {
+	return config.Load()
 }
 
 var rootCmd = &cobra.Command{
@@ -33,11 +33,18 @@ var rootCmd = &cobra.Command{
 	Long:          "imghost is the user-facing CLI for the imghostd daemon.",
 	SilenceUsage:  true,
 	SilenceErrors: true,
+	CompletionOptions: cobra.CompletionOptions{
+		DisableDefaultCmd: true,
+	},
 }
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(serviceCmd)
+	rootCmd.AddCommand(putCmd)
+	rootCmd.AddCommand(getCmd)
+	rootCmd.AddCommand(rmCmd)
+	rootCmd.AddCommand(aclCmd)
 }
 
 // Execute runs the cobra root command.
@@ -49,7 +56,7 @@ func Execute() error {
 // caller can exit non-zero. It is used as a PersistentPreRunE on every
 // non-version subcommand to guarantee CLI and daemon see the same config.
 func requireConfig(_ *cobra.Command, _ []string) error {
-	if err := configLoader(); err != nil {
+	if _, err := configLoader(); err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
 	return nil

--- a/cmd/imghost/cmd/root.go
+++ b/cmd/imghost/cmd/root.go
@@ -27,6 +27,11 @@ var configLoader = func() (*config.Config, error) {
 	return config.Load()
 }
 
+// cachedConfig holds the config loaded once per CLI invocation via
+// requireConfig, so HTTP subcommands do not re-read (and re-validate) the
+// TOML file on every RunE call.
+var cachedConfig *config.Config
+
 var rootCmd = &cobra.Command{
 	Use:           "imghost",
 	Short:         "imghost CLI",
@@ -56,8 +61,16 @@ func Execute() error {
 // caller can exit non-zero. It is used as a PersistentPreRunE on every
 // non-version subcommand to guarantee CLI and daemon see the same config.
 func requireConfig(_ *cobra.Command, _ []string) error {
-	if _, err := configLoader(); err != nil {
+	cfg, err := configLoader()
+	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
+	cachedConfig = cfg
 	return nil
+}
+
+// mustConfig returns the config loaded by requireConfig. HTTP subcommands
+// should call this from their RunE to avoid re-loading the TOML file.
+func mustConfig() *config.Config {
+	return cachedConfig
 }

--- a/cmd/imghost/cmd/service_test.go
+++ b/cmd/imghost/cmd/service_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/1996fanrui/imghost/internal/config"
 )
 
 type fakeAdapter struct {
@@ -25,7 +27,7 @@ func withTestEnv(t *testing.T, a serviceAdapter) func() {
 	origAdapter := adapter
 	origLoader := configLoader
 	adapter = a
-	configLoader = func() error { return nil }
+	configLoader = func() (*config.Config, error) { return &config.Config{}, nil }
 	return func() {
 		adapter = origAdapter
 		configLoader = origLoader
@@ -73,7 +75,7 @@ func TestServiceNotInstalledPrintsGuidance(t *testing.T) {
 func TestServiceRequireConfigFailure(t *testing.T) {
 	restore := withTestEnv(t, &fakeAdapter{})
 	defer restore()
-	configLoader = func() error { return io.ErrUnexpectedEOF }
+	configLoader = func() (*config.Config, error) { return nil, io.ErrUnexpectedEOF }
 	if _, err := runService(t, "service", "status"); err == nil {
 		t.Fatal("expected config load error to propagate")
 	}
@@ -89,7 +91,7 @@ func TestServiceWindowsExitsZeroForAllSubcommands(t *testing.T) {
 	restore := withTestEnv(t, fake)
 	defer restore()
 	// Simulate a missing / broken config on the host.
-	configLoader = func() error { return io.ErrUnexpectedEOF }
+	configLoader = func() (*config.Config, error) { return nil, io.ErrUnexpectedEOF }
 	origGOOS := serviceGOOS
 	serviceGOOS = "windows"
 	defer func() { serviceGOOS = origGOOS }()

--- a/cmd/imghostd/main.go
+++ b/cmd/imghostd/main.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/1996fanrui/imghost/internal/config"
@@ -29,6 +30,9 @@ func main() {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "config error:", err)
 		os.Exit(1)
+	}
+	if cfg.DefaultRootInjected {
+		log.Printf("config: no [[root]] configured; injecting %s -> %s", cfg.Roots[0].Name, cfg.Roots[0].Path)
 	}
 	if err := server.Start(context.Background(), cfg); err != nil {
 		fmt.Fprintln(os.Stderr, "server error:", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,7 +8,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -32,6 +31,11 @@ type Config struct {
 
 	// DBPath is derived during Load; it is not a TOML field.
 	DBPath string `toml:"-"`
+
+	// DefaultRootInjected is true when Load synthesized the built-in
+	// `_default` root because the user configured no [[root]]. The daemon
+	// logs this once at startup; the CLI stays silent.
+	DefaultRootInjected bool `toml:"-"`
 }
 
 const (
@@ -138,12 +142,12 @@ func injectDefaultRoot(cfg *Config) error {
 	if err := os.MkdirAll(path, 0o755); err != nil {
 		return fmt.Errorf("create default root %s: %w", path, err)
 	}
-	log.Printf("config: no [[root]] configured; injecting %s -> %s", defaultRootName, path)
 	cfg.Roots = append(cfg.Roots, Root{
 		Name:   defaultRootName,
 		Path:   path,
 		Access: permission.Public,
 	})
+	cfg.DefaultRootInjected = true
 	return nil
 }
 

--- a/scripts/install_local.sh
+++ b/scripts/install_local.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# install_local.sh — Build imghost + imghostd from the current source tree and
+# install them to ~/.local/bin, then (re)start the imghostd user service.
+#
+# Usage:
+#   bash scripts/install_local.sh
+#
+# Environment variables:
+#   GO_BIN=go                     # override the `go` binary
+#   IMGHOST_NO_MODIFY_PATH=1      # do not write PATH to shell profile
+#
+# Prerequisite: Go toolchain installed and reachable via ${GO_BIN}.
+#
+# This is the source-build counterpart to the release-binary install.sh at the
+# repo root. Keep the two scripts self-contained (no shared lib) so install.sh
+# stays curl|bash-safe as a single file.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+INSTALL_DIR="${HOME}/.local/bin"
+LAUNCHD_LABEL="com.imghost.imghostd"
+GO_BIN="${GO_BIN:-go}"
+
+check_go() {
+  if ! command -v "${GO_BIN}" >/dev/null 2>&1; then
+    echo "Error: ${GO_BIN} is required to build from source." >&2
+    exit 1
+  fi
+}
+
+detect_os() {
+  OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  if [[ "${OS}" != "linux" && "${OS}" != "darwin" ]]; then
+    echo "Error: unsupported OS for local install: ${OS}" >&2
+    exit 1
+  fi
+}
+
+build_binaries() {
+  mkdir -p "${INSTALL_DIR}"
+  cd "${PROJECT_ROOT}"
+
+  echo "Building imghost and imghostd from ${PROJECT_ROOT}..."
+  "${GO_BIN}" build -ldflags="-s -w" -o "${INSTALL_DIR}/imghost"  ./cmd/imghost
+  "${GO_BIN}" build -ldflags="-s -w" -o "${INSTALL_DIR}/imghostd" ./cmd/imghostd
+
+  echo "Installed: ${INSTALL_DIR}/imghost"
+  echo "Installed: ${INSTALL_DIR}/imghostd"
+}
+
+ensure_path() {
+  if [[ "${IMGHOST_NO_MODIFY_PATH:-0}" == "1" ]]; then
+    return
+  fi
+
+  case ":${PATH}:" in
+    *":${INSTALL_DIR}:"*)
+      return
+      ;;
+  esac
+
+  local shell_name
+  shell_name=$(basename "${SHELL:-/bin/bash}")
+
+  local profile=""
+  case "${shell_name}" in
+    zsh)  profile="${HOME}/.zshrc" ;;
+    bash)
+      if [[ "${OS}" == "darwin" ]]; then
+        profile="${HOME}/.bash_profile"
+      else
+        profile="${HOME}/.bashrc"
+      fi
+      ;;
+    *)    profile="${HOME}/.profile" ;;
+  esac
+
+  local marker_begin="# >>> imghost installer >>>"
+  local marker_end="# <<< imghost installer <<<"
+
+  if [[ -f "${profile}" ]] && grep -qF "${marker_begin}" "${profile}"; then
+    export PATH="${INSTALL_DIR}:${PATH}"
+    return
+  fi
+
+  {
+    echo ""
+    echo "${marker_begin}"
+    echo "export PATH=\"\$HOME/.local/bin:\$PATH\""
+    echo "${marker_end}"
+  } >> "${profile}"
+  echo "Added ${INSTALL_DIR} to PATH in ${profile}"
+
+  export PATH="${INSTALL_DIR}:${PATH}"
+}
+
+enable_linger() {
+  if ! loginctl enable-linger "${USER}" 2>/dev/null; then
+    echo "Warning: loginctl enable-linger failed; the daemon may stop when you log out." >&2
+    echo "         You can retry later with: sudo loginctl enable-linger ${USER}" >&2
+  fi
+}
+
+setup_systemd() {
+  local service_dir="${HOME}/.config/systemd/user"
+  local service_file="${service_dir}/imghostd.service"
+
+  mkdir -p "${service_dir}"
+
+  cat > "${service_file}.tmp" <<EOF
+[Unit]
+Description=imghost daemon
+
+[Service]
+Type=simple
+ExecStart=${INSTALL_DIR}/imghostd
+SuccessExitStatus=143
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target
+EOF
+
+  mv -f "${service_file}.tmp" "${service_file}"
+
+  systemctl --user daemon-reload
+  systemctl --user enable imghostd
+  systemctl --user restart imghostd
+}
+
+setup_launchd() {
+  local agents_dir="${HOME}/Library/LaunchAgents"
+  local plist_file="${agents_dir}/${LAUNCHD_LABEL}.plist"
+
+  mkdir -p "${agents_dir}"
+  mkdir -p "${HOME}/Library/Logs"
+
+  cat > "${plist_file}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>          <string>${LAUNCHD_LABEL}</string>
+  <key>ProgramArguments</key><array><string>${INSTALL_DIR}/imghostd</string></array>
+  <key>RunAtLoad</key>      <true/>
+  <key>KeepAlive</key>
+    <dict><key>SuccessfulExit</key><false/></dict>
+  <key>StandardOutPath</key><string>${HOME}/Library/Logs/imghostd.log</string>
+  <key>StandardErrorPath</key><string>${HOME}/Library/Logs/imghostd.log</string>
+</dict>
+</plist>
+EOF
+
+  local domain target
+  domain="gui/$(id -u)"
+  target="${domain}/${LAUNCHD_LABEL}"
+
+  if launchctl print "${target}" >/dev/null 2>&1; then
+    launchctl bootout "${target}"
+  fi
+  launchctl bootstrap "${domain}" "${plist_file}"
+}
+
+print_summary() {
+  echo ""
+  echo "Local install complete."
+  echo "  CLI    : ${INSTALL_DIR}/imghost"
+  echo "  daemon : ${INSTALL_DIR}/imghostd"
+  case "${OS}" in
+    linux)  echo "Service: systemctl --user status imghostd" ;;
+    darwin) echo "Service: launchctl list | grep imghostd" ;;
+  esac
+  echo "Swagger UI: http://localhost:34286/swagger/index.html"
+}
+
+main() {
+  check_go
+  detect_os
+  build_binaries
+  ensure_path
+  case "${OS}" in
+    linux)  enable_linger; setup_systemd ;;
+    darwin) setup_launchd ;;
+  esac
+  print_summary
+}
+
+main "$@"


### PR DESCRIPTION
Close #9

## Summary
- Disable cobra's auto-generated `completion` subcommand.
- Add six HTTP-client subcommands to `imghost` that wrap the existing daemon API: `put`, `get`, `rm`, and `acl get|set|rm`.
- Read `listen_addr` + `api_key` from the shared XDG `config.toml` (no env overrides), keeping CLI and daemon on one source of truth.
- Surface non-2xx responses as non-zero exit with the server's structured error body.

Restores the capabilities of the old `scripts/imghost` bash wrapper (removed in bcf3cb2 during the native-binary refactor) that were not ported when the cobra CLI was introduced.

## Test plan
- [x] `go vet ./...`
- [x] `bash scripts/run_test.sh`
- [x] New unit tests cover all six subcommands (via `httptest`), invalid access rejection, and non-2xx propagation
- [x] `imghost --help` no longer lists `completion`; lists `put`, `get`, `rm`, `acl`
